### PR TITLE
Add `g:hey_openai_api_key` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Note that if you're using [denops-shared-server](https://github.com/vim-denops/d
 
 ## Options
 
-- `g:hey_openai_api_key` - Set the OpenAI API key to use. Defaults is not set, `OPENAI_API_KEY` environment variable is used.
-- `g:hey_model_name` - Set the model name to use. Defaults `"gpt-3.5-turbo"`
-- `g:hey_verbose` - Set verbose mode. Defaults `v:false`.
+- `g:hey_openai_api_key` - Set the OpenAI API key to use. If the value is not set, the `OPENAI_API_KEY` environment variable will be used.
+- `g:hey_model_name` - Set the model name to use. The default is `"gpt-3.5-turbo"`.
+- `g:hey_verbose` - Set the verbose mode. The default is `v:false`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -19,10 +19,18 @@ Plug 'tani/hey.vim'
 
 You need to set OpenAI API key as `OPENAI_API_KEY` environment variable.
 
+Note that if you're using [denops-shared-server](https://github.com/vim-denops/denops-shared-server.vim), the environment variables are separate from Vim. In that case, set it to `g:hey_openai_api_key`.
+
 ## Commands
 
 - `[range]Hey {prompt}` - Edit text with OpenAI API.
 - `HeyAbort` - Abort the current edit.
+
+## Options
+
+- `g:hey_openai_api_key` - Set the OpenAI API key to use. Defaults is not set, `OPENAI_API_KEY` environment variable is used.
+- `g:hey_model_name` - Set the model name to use. Defaults `"gpt-3.5-turbo"`
+- `g:hey_verbose` - Set verbose mode. Defaults `v:false`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Plug 'tani/hey.vim'
 
 You need to set OpenAI API key as `OPENAI_API_KEY` environment variable.
 
-Note that if you're using [denops-shared-server](https://github.com/vim-denops/denops-shared-server.vim), the environment variables are separate from Vim. In that case, set it to `g:hey_openai_api_key`.
+Note that if you're using [denops-shared-server](https://github.com/vim-denops/denops-shared-server.vim), the environment variable is separate from Vim. In this case, you should set it to `g:hey_openai_api_key`.
 
 ## Commands
 

--- a/denops/hey/main.ts
+++ b/denops/hey/main.ts
@@ -46,6 +46,7 @@ async function hey(denops: Denops, firstline: number, lastline: number, request:
 
   const mutex = new Mutex();
   const model = new ChatOpenAI({
+    openAIApiKey: await vars.g.get<string | undefined>(denops, "hey_openai_api_key", undefined),
     modelName: await vars.g.get(denops, "hey_model_name", "gpt-3.5-turbo"),
     verbose: await vars.g.get(denops, "hey_verbose", false),
     streaming: true,


### PR DESCRIPTION
It is inconvenient that there is only an environment variable for setting the API Key.

## Motivation

- I had a problem when using denops-shared-server.
- I don't want to set the API Key to a global environment variable.
- I want to use different API Keys depending on the purpose.