### PR TITLE
fix: :Hey command errors when buffer is modified and nohidden

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Use these commands:
 
 - `:[range]Hey[!] {prompt}` - Edit text. With !, the text is replaced inplace.
 - `:HeyAbort` - Abort the current asynchronous operation.
+- `:HeyClose` - Close the Hey popup or window.
 
 See `:help hey-commands` for more information.
 

--- a/denops/hey/main.ts
+++ b/denops/hey/main.ts
@@ -130,6 +130,10 @@ export const main: Entrypoint = async (denops) => {
         controller = undefined;
       }
     },
+    async close() {
+      await closePopup(denops);
+      await closeWindow(denops);
+    },
     abort,
   };
 
@@ -143,6 +147,11 @@ export const main: Entrypoint = async (denops) => {
       call denops#notify("${denops.name}", "abort", [])
     endfunction
     command! HeyAbort call HeyAbort()
+
+    function! HeyClose() abort
+      call denops#notify("${denops.name}", "close", [])
+    endfunction
+    command! HeyClose call HeyClose()
   `);
 
   return {

--- a/denops/hey/window.ts
+++ b/denops/hey/window.ts
@@ -1,0 +1,101 @@
+import type { Denops } from "jsr:@denops/std@7";
+import { batch } from "jsr:@denops/std@7/batch";
+import * as fn from "jsr:@denops/std@7/function";
+import * as option from "jsr:@denops/std@7/option";
+import * as popup from "https://lib.deno.dev/x/denops_popup@2/mod.ts";
+
+type DenopsForPopup = Parameters<typeof popup.open>[0];
+
+/**
+ * Opens the "heyvim" buffer in a new popup window.
+ *
+ * @param denops - Denops instance for Vim/Neovim API interaction.
+ * @returns A Promise resolving to ["heyvim" buffer number, window id]
+ */
+export async function showPopup(
+  denops: Denops,
+): Promise<[bufnr: number, winid: number]> {
+  const bufnr = await initBuffer(denops);
+  const winh = await fn.winheight(denops, "%") as number;
+  const winw = await fn.winwidth(denops, "%") as number;
+  const poph = Math.floor(winh * 0.8);
+  const popw = Math.floor(winw * 0.8);
+  const row = Math.floor((winh - poph) / 2);
+  const col = Math.floor((winw - popw) / 2);
+  const winid = await popup.open(denops as DenopsForPopup, bufnr, {
+    row, col, height: poph, width: popw, origin: "topleft", border: true,
+  });
+  await initWindow(denops, winid);
+  await fn.win_gotoid(denops, winid);
+  return [bufnr, winid];
+}
+
+/**
+ * Closes the "heyvim" popup window.
+ *
+ * @param denops - Denops instance for Vim/Neovim API interaction.
+ */
+export async function closePopup(denops: Denops): Promise<void> {
+  const bufnr = await fn.bufnr(denops, "heyvim");
+  if (bufnr < 0) return;
+  for (const winid of await popup.list(denops as DenopsForPopup)) {
+    if (bufnr === await fn.winbufnr(denops, winid)) {
+      await popup.close(denops as DenopsForPopup, winid);
+    }
+  }
+}
+
+/**
+ * Opens the "heyvim" buffer in a new window.
+ * When the window is already open, it will be reused. 
+ *
+ * @param denops - Denops instance for Vim/Neovim API interaction.
+ * @returns A Promise resolving to ["heyvim" buffer number, window id].
+ */
+export async function showWindow(
+  denops: Denops,
+): Promise<[bufnr: number, winid: number]> {
+  const bufnr = await initBuffer(denops);
+  let winid = await fn.bufwinid(denops, bufnr);
+  if (winid < 0) {
+    await denops.cmd(`rightbelow vertical sbuffer ${bufnr}`);
+    winid = await fn.win_getid(denops);
+  }
+  await initWindow(denops, winid);
+  await fn.win_gotoid(denops, winid);
+  return [bufnr, winid];
+}
+
+/**
+ * Closes the "heyvim" window.
+ *
+ * @param denops - Denops instance for Vim/Neovim API interaction.
+ */
+export async function closeWindow(denops: Denops): Promise<void> {
+  const bufnr = await fn.bufnr(denops, "heyvim");
+  if (bufnr < 0) return;
+  for (const id of await fn.win_findbuf(denops, bufnr) as number[]) {
+    await fn.win_execute(denops, id, "close");
+  }
+}
+
+async function initBuffer(denops: Denops): Promise<number> {
+  const bufnr = await fn.bufnr(denops, "heyvim", true);
+  await batch(denops, async (denops) => {
+    await option.buftype.setBuffer(denops, bufnr, "nofile");
+    await option.buflisted.setBuffer(denops, bufnr, false);
+    await option.swapfile.setBuffer(denops, bufnr, false);
+    await option.filetype.setBuffer(denops, bufnr, "markdown");
+    await fn.deletebufline(denops, bufnr, 1, "$");
+  });
+  return bufnr;
+}
+
+async function initWindow(denops: Denops, winnr: number): Promise<void> {
+  await batch(denops, async (denops) => {
+    await option.number.setWindow(denops, winnr, false);
+    await option.relativenumber.setWindow(denops, winnr, false);
+    await option.signcolumn.setWindow(denops, winnr, "no");
+    await option.wrap.setWindow(denops, winnr, true);
+  });
+}

--- a/denops/hey/window.ts
+++ b/denops/hey/window.ts
@@ -6,6 +6,8 @@ import * as popup from "https://lib.deno.dev/x/denops_popup@2/mod.ts";
 
 type DenopsForPopup = Parameters<typeof popup.open>[0];
 
+const HEYVIM_BUFFER_NAME = "heyvim";
+
 /**
  * Opens the "heyvim" buffer in a new popup window.
  *
@@ -36,7 +38,7 @@ export async function showPopup(
  * @param denops - Denops instance for Vim/Neovim API interaction.
  */
 export async function closePopup(denops: Denops): Promise<void> {
-  const bufnr = await fn.bufnr(denops, "heyvim");
+  const bufnr = await fn.bufnr(denops, HEYVIM_BUFFER_NAME);
   if (bufnr < 0) return;
   for (const winid of await popup.list(denops as DenopsForPopup)) {
     if (bufnr === await fn.winbufnr(denops, winid)) {
@@ -72,7 +74,7 @@ export async function showWindow(
  * @param denops - Denops instance for Vim/Neovim API interaction.
  */
 export async function closeWindow(denops: Denops): Promise<void> {
-  const bufnr = await fn.bufnr(denops, "heyvim");
+  const bufnr = await fn.bufnr(denops, HEYVIM_BUFFER_NAME);
   if (bufnr < 0) return;
   for (const id of await fn.win_findbuf(denops, bufnr) as number[]) {
     await fn.win_execute(denops, id, "close");
@@ -80,7 +82,7 @@ export async function closeWindow(denops: Denops): Promise<void> {
 }
 
 async function initBuffer(denops: Denops): Promise<number> {
-  const bufnr = await fn.bufnr(denops, "heyvim", true);
+  const bufnr = await fn.bufnr(denops, HEYVIM_BUFFER_NAME, true);
   await batch(denops, async (denops) => {
     await option.buftype.setBuffer(denops, bufnr, "nofile");
     await option.buflisted.setBuffer(denops, bufnr, false);

--- a/doc/hey.txt
+++ b/doc/hey.txt
@@ -107,5 +107,9 @@ COMMANDS							*hey-commands*
 :HeyAbort
 		Abort the current asynchronous operation.
 
+								   *:HeyClose*
+:HeyClose
+		Close the Hey popup or window.
+
 
  vim:tw=78:ts=8:noet:ft=help:norl:


### PR DESCRIPTION
Problem: The current buffer is *abandoned* before open the "heyvim" window, causing an error if the current buffer was `modified` and `nohidden`.
Solution: Create the window to be displayed first.

Problem: In Vim, user can't close a popup (because it doesn't get focus).
Solution: Add the `:HeyClose` command.